### PR TITLE
Run on port 8000 by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY . .
 
 # Run a single uvicorn worker
 # Multiple workers are managed by kubernetes, rather than something like gunicorn
-CMD ["uvicorn", "--proxy-headers", "--host", "0.0.0.0", "--port", "80", "patsy.main:app"]
+CMD ["uvicorn", "--proxy-headers", "--host", "0.0.0.0", "--port", "8000", "patsy.main:app"]


### PR DESCRIPTION
Port 80 is privileged. While the Dockerfile currently instructs the
container to run as root, in environments like our Kubernetes cluster we
do not want the service to run as root.

We can also theoretically drop to an unprivileged user here (for
instance using `USER nobody`), this is left out for now.

References: https://github.com/python-discord/kubernetes/pull/103