### PR TITLE
Replicate prod-like env in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     command: ["uvicorn", "--reload", "--host", "0.0.0.0", "--port", "8000", "patsy.main:app"]
     volumes:
       - .:/patsy:ro
+    read_only: true  # Prod uses a read-only fs, override this locally if it helps with debugging
+    user: "65534"  # Prod uses a non-root user, override this locally if it helps with debugging
     tty: true
     depends_on:
       postgres:


### PR DESCRIPTION
In production we have a read-only fs and a non-root user. Replicating these conditions in dev ensures that issues with this setup are discovered during dev, rather than when deployed to prod.