### PR TITLE
minor: add missing word to commiting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ Once your `.env` file is setup, start postgres by running `docker-compose up pos
 This will create a migration file in the path `alembic_conf/versions`. Make sure to check it over, and fix any flake8 issues.
 
 ## Committing
-Before committing make sure to run `poetry install` and then `poetry run precommit` to install the project dependencies and the pre-commit hook.
+Before committing make sure to run `poetry install` and then `poetry run task precommit` to install the project dependencies and the pre-commit hook.


### PR DESCRIPTION
`poetry run precommit` is not valid, must be `poetry run task precommit`